### PR TITLE
Disable the fade animation in all views when in lowpower mode

### DIFF
--- a/1080i/View_Episodes.xml
+++ b/1080i/View_Episodes.xml
@@ -12,7 +12,7 @@
                 <aspectratio scalediffuse="false">stretch</aspectratio>
                 <texture background="true" fallback="colors/black.png" border="0">$INFO[container.art(fanart)]</texture>
                 <colordiffuse>ffffffff</colordiffuse>
-                <animation type="conditional" condition="!controlgroup(9000).hasfocus" loop="true" reversible="false">
+                <animation type="conditional" condition="!controlgroup(9000).hasfocus + !Skin.HasSetting(lowPowerMode)" loop="true" reversible="false">
                     <effect type="fade" start="0" end="100" time="2000"/>
                     <effect type="zoom" center="auto" start="130" end="100" time="15000"/>
                     <effect type="fade" start="100" end="0" time="1000" delay="14000"/>

--- a/1080i/View_Seasons.xml
+++ b/1080i/View_Seasons.xml
@@ -13,7 +13,7 @@
                     <aspectratio scalediffuse="false">stretch</aspectratio>
                     <texture background="true" fallback="colors/offblack.png" border="0">$INFO[container.art(fanart)]</texture>
                     <colordiffuse>ffffffff</colordiffuse>
-                    <animation type="conditional" condition="!controlgroup(9000).hasfocus" loop="true" reversible="false">
+                    <animation type="conditional" condition="!controlgroup(9000).hasfocus + !Skin.HasSetting(lowPowerMode)" loop="true" reversible="false">
                         <effect type="fade" start="0" end="100" time="2000"/>
                         <effect type="zoom" center="auto" start="130" end="100" time="15000"/>
                         <effect type="fade" start="100" end="0" time="1000" delay="14000"/>


### PR DESCRIPTION
Following b66d8d0, this also disables the (only) remaining background animations in the episodes and season views when in low power mode.